### PR TITLE
Improve client search UX and fix editing modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,1054 @@
+// Registro Live Mystery Product - gestione logica applicativa
+(function () {
+  const DB_NAME = 'mystery-product-db';
+  const DB_VERSION = 1;
+  const STORES = { CLIENTS: 'clients', PURCHASES: 'purchases' };
+  const PRICE_SHORTCUTS = {
+    'Digit1': 3,
+    'Digit2': 5,
+    'Digit3': 7,
+    'Digit4': 10,
+    'Digit5': 12,
+    'Digit6': 15,
+    'Digit7': 20,
+    'Digit8': 25,
+    'Digit9': 30,
+    'Digit0': 35,
+    'Equal': 40,
+    'Numpad1': 3,
+    'Numpad2': 5,
+    'Numpad3': 7,
+    'Numpad4': 10,
+    'Numpad5': 12,
+    'Numpad6': 15,
+    'Numpad7': 20,
+    'Numpad8': 25,
+    'Numpad9': 30,
+    'Numpad0': 35
+  };
+
+  let db;
+  let clientsCache = [];
+  let selectedClientId = null;
+  let currentFilter = 'tutti';
+  let currentPrice = null;
+  let currentState = 'acquistato';
+  let searchResults = [];
+  let keyboardIndex = -1;
+  let lastAddedPurchase = null;
+  let undoTimer = null;
+  let editingPurchaseId = null;
+  let suggestionResults = [];
+
+  const dom = {};
+
+  document.addEventListener('DOMContentLoaded', init);
+
+  // Inizializza il database, la UI e popola i dati demo
+  async function init() {
+    mapDom();
+    attachListeners();
+    dom.productName.addEventListener('input', updateAddButtonState);
+    db = await openDatabase();
+    await ensureDemoData();
+    await loadClients();
+    renderClientList(clientsCache);
+    clearSearchSuggestions();
+    updateStats();
+    updateAddButtonState();
+  }
+
+  // Collega gli elementi del DOM a un dizionario per uso rapido
+  function mapDom() {
+    dom.clientSearch = document.getElementById('clientSearch');
+    dom.clientList = document.getElementById('clientList');
+    dom.searchSuggestions = document.getElementById('searchSuggestions');
+    dom.newClient = document.getElementById('newClient');
+    dom.selectedClientName = document.getElementById('selectedClientName');
+    dom.selectedClientNotes = document.getElementById('selectedClientNotes');
+    dom.clientTotal = document.getElementById('clientTotal');
+    dom.productName = document.getElementById('productName');
+    dom.customPrice = document.getElementById('customPrice');
+    dom.quickPrices = document.querySelectorAll('.quick-prices button');
+    dom.stateToggle = document.querySelectorAll('.state-toggle button');
+    dom.purchaseForm = document.getElementById('purchaseForm');
+    dom.addPurchase = document.getElementById('addPurchase');
+    dom.historyBody = document.getElementById('historyBody');
+    dom.tabs = document.querySelectorAll('.tabs button');
+    dom.undoLast = document.getElementById('undoLast');
+    dom.toastContainer = document.getElementById('toastContainer');
+    dom.themeToggle = document.getElementById('themeToggle');
+    dom.exportPdf = document.getElementById('exportPdf');
+    dom.exportJson = document.getElementById('exportJson');
+    dom.importJsonInput = document.getElementById('importJsonInput');
+    dom.resetDb = document.getElementById('resetDb');
+    dom.statClients = document.getElementById('statClients');
+    dom.statPurchases = document.getElementById('statPurchases');
+    dom.statTotal = document.getElementById('statTotal');
+    dom.modal = document.getElementById('modal');
+    dom.modalForm = document.getElementById('modalForm');
+    dom.modalCancel = document.getElementById('modalCancel');
+    dom.modalSave = document.getElementById('modalSave');
+    dom.modalNome = document.getElementById('modalNome');
+    dom.modalCognome = document.getElementById('modalCognome');
+    dom.modalNote = document.getElementById('modalNote');
+    dom.purchaseModal = document.getElementById('purchaseModal');
+    dom.purchaseModalForm = document.getElementById('purchaseModalForm');
+    dom.purchaseModalCancel = document.getElementById('purchaseModalCancel');
+    dom.purchaseModalProduct = document.getElementById('purchaseModalProduct');
+    dom.purchaseModalPrice = document.getElementById('purchaseModalPrice');
+    dom.purchaseModalState = document.getElementById('purchaseModalState');
+    dom.purchaseModalSave = document.getElementById('purchaseModalSave');
+  }
+
+  // Gestisce tutti gli ascoltatori di eventi
+  function attachListeners() {
+    dom.clientSearch.addEventListener('input', debounce(handleSearch, 150));
+    dom.clientSearch.addEventListener('keydown', handleSearchKeys);
+    dom.clientSearch.addEventListener('blur', () => setTimeout(() => clearSearchSuggestions(), 120));
+    dom.newClient.addEventListener('click', () => openClientModal());
+    dom.clientList.addEventListener('click', handleClientClick);
+
+    dom.quickPrices.forEach(btn => {
+      btn.addEventListener('click', () => {
+        dom.customPrice.value = '';
+        setActivePrice(Number(btn.dataset.price));
+      });
+    });
+
+    dom.customPrice.addEventListener('input', () => {
+      if (!dom.customPrice.value) {
+        currentPrice = null;
+      } else {
+        currentPrice = parsePrice(dom.customPrice.value);
+      }
+      clearActiveQuickPrice();
+      updateAddButtonState();
+    });
+
+    dom.stateToggle.forEach(btn => {
+      btn.addEventListener('click', () => {
+        dom.stateToggle.forEach(b => {
+          b.classList.remove('active');
+          b.setAttribute('aria-pressed', 'false');
+        });
+        btn.classList.add('active');
+        btn.setAttribute('aria-pressed', 'true');
+        currentState = btn.dataset.state;
+      });
+    });
+
+    dom.purchaseForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      await handleAddPurchase();
+    });
+
+    dom.tabs.forEach(tab => tab.addEventListener('click', async () => {
+      dom.tabs.forEach(t => t.classList.remove('active'));
+      tab.classList.add('active');
+      currentFilter = tab.dataset.filter;
+      await renderHistory();
+    }));
+
+    dom.undoLast.addEventListener('click', undoLastInsert);
+    dom.themeToggle.addEventListener('click', toggleTheme);
+    dom.exportPdf.addEventListener('click', exportPdf);
+    dom.exportJson.addEventListener('click', exportJson);
+    dom.importJsonInput.addEventListener('change', importJson);
+    dom.resetDb.addEventListener('click', resetDatabase);
+
+    dom.modalCancel.addEventListener('click', closeModal);
+    dom.modalForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      await saveClientFromModal();
+    });
+
+    dom.purchaseModalCancel.addEventListener('click', closePurchaseModal);
+    dom.purchaseModal.addEventListener('mousedown', (event) => {
+      if (event.target === dom.purchaseModal) closePurchaseModal();
+    });
+    dom.modal.addEventListener('mousedown', (event) => {
+      if (event.target === dom.modal) closeModal();
+    });
+    dom.purchaseModalForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      await savePurchaseFromModal();
+    });
+
+    document.addEventListener('keydown', handleGlobalShortcuts);
+  }
+
+  // Inizializza IndexedDB creando gli store necessari
+  function openDatabase() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = (event) => {
+        const dbInstance = event.target.result;
+        if (!dbInstance.objectStoreNames.contains(STORES.CLIENTS)) {
+          const clientStore = dbInstance.createObjectStore(STORES.CLIENTS, { keyPath: 'id' });
+          clientStore.createIndex('byName', 'nome');
+          clientStore.createIndex('bySurname', 'cognome');
+          clientStore.createIndex('bySearch', 'search');
+        }
+        if (!dbInstance.objectStoreNames.contains(STORES.PURCHASES)) {
+          const purchaseStore = dbInstance.createObjectStore(STORES.PURCHASES, { keyPath: 'id' });
+          purchaseStore.createIndex('byClient', 'clientId');
+          purchaseStore.createIndex('byTimestamp', 'timestamp');
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  // Assicura la presenza di dati demo al primo avvio
+  async function ensureDemoData() {
+    const tx = db.transaction(STORES.CLIENTS, 'readonly');
+    const store = tx.objectStore(STORES.CLIENTS);
+    const count = await requestToPromise(store.count());
+    if (count > 0) return;
+
+    const demoClients = [
+      { id: crypto.randomUUID(), nome: 'Giulia', cognome: 'Moretti', note: 'Preferisce prodotti skincare', search: normalizeSearch('Giulia', 'Moretti') },
+      { id: crypto.randomUUID(), nome: 'Luca', cognome: 'Bianchi', note: 'Pagamenti in contanti', search: normalizeSearch('Luca', 'Bianchi') }
+    ];
+
+    const now = Date.now();
+    const demoPurchases = [
+      { id: crypto.randomUUID(), clientId: demoClients[0].id, prodotto: 'Siero illuminante', prezzo: 25, stato: 'acquistato', timestamp: new Date(now - 3600_000).toISOString() },
+      { id: crypto.randomUUID(), clientId: demoClients[0].id, prodotto: 'Maschera notte', prezzo: 15, stato: 'aggiunto', timestamp: new Date(now - 1800_000).toISOString() },
+      { id: crypto.randomUUID(), clientId: demoClients[1].id, prodotto: 'Crema nutriente', prezzo: 20, stato: 'acquistato', timestamp: new Date(now - 5400_000).toISOString() },
+      { id: crypto.randomUUID(), clientId: demoClients[1].id, prodotto: 'Mystery deluxe', prezzo: 35, stato: 'acquistato', timestamp: new Date(now - 900_000).toISOString() }
+    ];
+
+    const writeTx = db.transaction([STORES.CLIENTS, STORES.PURCHASES], 'readwrite');
+    const clientStore = writeTx.objectStore(STORES.CLIENTS);
+    const purchaseStore = writeTx.objectStore(STORES.PURCHASES);
+    for (const client of demoClients) {
+      clientStore.add(client);
+    }
+    for (const purchase of demoPurchases) {
+      purchaseStore.add(purchase);
+    }
+    await transactionComplete(writeTx);
+  }
+
+  // Carica tutti i clienti in cache
+  async function loadClients() {
+    const tx = db.transaction(STORES.CLIENTS, 'readonly');
+    const store = tx.objectStore(STORES.CLIENTS);
+    clientsCache = await requestToPromise(store.getAll());
+    clientsCache.sort((a, b) => a.cognome.localeCompare(b.cognome, 'it', { sensitivity: 'base' }));
+  }
+
+  // Renderizza la lista clienti nel pannello sinistro
+  function renderClientList(list) {
+    dom.clientList.innerHTML = '';
+    searchResults = list;
+    keyboardIndex = -1;
+    for (const client of list) {
+      const li = document.createElement('li');
+      li.dataset.id = client.id;
+      li.tabIndex = 0;
+      const name = document.createElement('span');
+      name.className = 'name';
+      name.textContent = `${client.cognome} ${client.nome}`;
+      li.appendChild(name);
+      if (client.note) {
+        const note = document.createElement('span');
+        note.className = 'note';
+        note.textContent = client.note;
+        li.appendChild(note);
+      }
+      if (client.id === selectedClientId) {
+        li.classList.add('selected');
+      }
+      dom.clientList.appendChild(li);
+    }
+  }
+
+  function handleClientClick(event) {
+    const li = event.target.closest('li');
+    if (!li) return;
+    selectClient(li.dataset.id);
+    clearSearchSuggestions();
+  }
+
+  function renderSearchSuggestions(list, term) {
+    if (!term || term.length < 2 || !list.length) {
+      clearSearchSuggestions();
+      return;
+    }
+    dom.searchSuggestions.innerHTML = '';
+    const slice = list.slice(0, 6);
+    suggestionResults = slice;
+    dom.searchSuggestions.scrollTop = 0;
+    keyboardIndex = -1;
+    for (const client of slice) {
+      const li = document.createElement('li');
+      li.dataset.id = client.id;
+      li.innerHTML = formatSuggestionLabel(client, term);
+      li.tabIndex = -1;
+      li.setAttribute('role', 'option');
+      li.setAttribute('aria-selected', 'false');
+      li.addEventListener('mousedown', async (event) => {
+        event.preventDefault();
+        dom.clientSearch.value = '';
+        renderClientList(filterClients(''));
+        await selectClient(client.id);
+      });
+      dom.searchSuggestions.appendChild(li);
+    }
+    dom.searchSuggestions.hidden = false;
+    dom.clientSearch.setAttribute('aria-expanded', 'true');
+  }
+
+  function formatSuggestionLabel(client, term) {
+    const fullName = `${client.nome} ${client.cognome}`;
+    const reversed = `${client.cognome} ${client.nome}`;
+    const target = fullName.toLowerCase().includes(term) ? fullName : reversed;
+    const highlighted = highlightTerm(target, term);
+    const details = client.note ? `<small>${escapeHtml(client.note)}</small>` : '';
+    return `<strong>${highlighted}</strong>${details}`;
+  }
+
+  function highlightTerm(text, term) {
+    const tokens = term.split(/\s+/).filter(Boolean);
+    let html = escapeHtml(text);
+    for (const token of tokens) {
+      const regex = new RegExp(escapeRegex(token), 'ig');
+      html = html.replace(regex, match => `<mark>${match}</mark>`);
+    }
+    return html;
+  }
+
+  function escapeHtml(str) {
+    if (str === null || str === undefined) return '';
+    return str.replace(/[&<>"']/g, char => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    }[char] || char));
+  }
+
+  function escapeRegex(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function clearSearchSuggestions() {
+    dom.searchSuggestions.hidden = true;
+    dom.searchSuggestions.innerHTML = '';
+    keyboardIndex = -1;
+    suggestionResults = [];
+    dom.clientSearch.setAttribute('aria-expanded', 'false');
+  }
+
+  function filterClients(term) {
+    if (!term) {
+      return clientsCache.slice();
+    }
+    const tokens = term.split(/\s+/).filter(Boolean);
+    const matches = clientsCache.filter(client => {
+      const normalized = `${client.nome} ${client.cognome}`.toLowerCase();
+      const reversed = `${client.cognome} ${client.nome}`.toLowerCase();
+      return tokens.every(tok => normalized.includes(tok) || reversed.includes(tok));
+    });
+    const priority = tokens[0] || term;
+    matches.sort((a, b) => {
+      const diff = scoreClient(a, priority) - scoreClient(b, priority);
+      if (diff !== 0) return diff;
+      return a.cognome.localeCompare(b.cognome, 'it', { sensitivity: 'base' });
+    });
+    return matches;
+  }
+
+  function scoreClient(client, term) {
+    const normalized = `${client.nome} ${client.cognome}`.toLowerCase();
+    const reversed = `${client.cognome} ${client.nome}`.toLowerCase();
+    const directIndex = normalized.indexOf(term);
+    const reverseIndex = reversed.indexOf(term);
+    const directScore = directIndex >= 0 ? directIndex : Number.MAX_SAFE_INTEGER;
+    const reverseScore = reverseIndex >= 0 ? reverseIndex + 0.1 : Number.MAX_SAFE_INTEGER;
+    return Math.min(directScore, reverseScore);
+  }
+
+  // Seleziona un cliente e carica il relativo storico
+  async function selectClient(id) {
+    selectedClientId = id;
+    updateClientSelectionUI();
+    await renderHistory();
+    dom.productName.focus();
+    updateAddButtonState();
+    clearSearchSuggestions();
+  }
+
+  function updateClientSelectionUI() {
+    dom.clientList.querySelectorAll('li').forEach(li => {
+      li.classList.toggle('selected', li.dataset.id === selectedClientId);
+      li.classList.remove('keyboard-focus');
+    });
+    const client = clientsCache.find(c => c.id === selectedClientId);
+    if (client) {
+      dom.selectedClientName.textContent = `${client.cognome} ${client.nome}`;
+      dom.selectedClientNotes.textContent = client.note || '';
+    } else {
+      dom.selectedClientName.textContent = 'Seleziona un cliente';
+      dom.selectedClientNotes.textContent = '';
+      dom.clientTotal.textContent = formatCurrency(0);
+    }
+  }
+
+  // Recupera e mostra lo storico acquisti del cliente selezionato
+  async function renderHistory() {
+    dom.historyBody.innerHTML = '';
+    if (!selectedClientId) {
+      dom.clientTotal.textContent = formatCurrency(0);
+      return;
+    }
+    const purchases = await getPurchasesForClient(selectedClientId);
+    const filtered = purchases.filter(p => {
+      if (currentFilter === 'tutti') return true;
+      return p.stato === currentFilter;
+    });
+    for (const purchase of filtered) {
+      const tr = document.createElement('tr');
+
+      const timeCell = document.createElement('td');
+      timeCell.textContent = formatTime(purchase.timestamp);
+      tr.appendChild(timeCell);
+
+      const productCell = document.createElement('td');
+      productCell.textContent = purchase.prodotto;
+      tr.appendChild(productCell);
+
+      const priceCell = document.createElement('td');
+      priceCell.textContent = formatCurrency(purchase.prezzo);
+      tr.appendChild(priceCell);
+
+      const statusCell = document.createElement('td');
+      const badge = document.createElement('span');
+      badge.className = `badge ${purchase.stato}`;
+      badge.textContent = capitalize(purchase.stato);
+      statusCell.appendChild(badge);
+      tr.appendChild(statusCell);
+
+      const actionsCell = document.createElement('td');
+      actionsCell.className = 'actions';
+      actionsCell.appendChild(createActionButton('✏️', 'edit', purchase.id));
+      actionsCell.appendChild(createActionButton('🔁', 'toggle', purchase.id));
+      actionsCell.appendChild(createActionButton('🗑️', 'delete', purchase.id));
+      tr.appendChild(actionsCell);
+
+      dom.historyBody.appendChild(tr);
+    }
+    const total = purchases.filter(p => p.stato === 'acquistato')
+      .reduce((sum, p) => sum + Number(p.prezzo), 0);
+    dom.clientTotal.textContent = formatCurrency(total);
+  }
+
+  function handleHistoryAction(event) {
+    const action = event.currentTarget.dataset.action;
+    const id = event.currentTarget.dataset.id;
+    if (action === 'edit') editPurchase(id);
+    if (action === 'toggle') togglePurchaseState(id);
+    if (action === 'delete') deletePurchase(id);
+  }
+
+  // Crea un pulsante per la tabella storico con azione associata
+  function createActionButton(label, action, id) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = label;
+    btn.dataset.action = action;
+    btn.dataset.id = id;
+    btn.addEventListener('click', handleHistoryAction);
+    return btn;
+  }
+
+  // Recupera acquisti per cliente da IndexedDB
+  async function getPurchasesForClient(clientId) {
+    const tx = db.transaction(STORES.PURCHASES, 'readonly');
+    const store = tx.objectStore(STORES.PURCHASES);
+    const index = store.index('byClient');
+    const request = index.getAll(IDBKeyRange.only(clientId));
+    const purchases = await requestToPromise(request);
+    purchases.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+    return purchases;
+  }
+
+  async function handleAddPurchase() {
+    if (!selectedClientId) {
+      showToast('Seleziona un cliente', 'error');
+      return;
+    }
+    const product = dom.productName.value.trim();
+    if (!product) {
+      showToast('Inserisci il nome prodotto', 'error');
+      return;
+    }
+    if (currentPrice === null || Number.isNaN(currentPrice)) {
+      showToast('Seleziona o inserisci un prezzo valido', 'error');
+      return;
+    }
+    const purchase = {
+      id: crypto.randomUUID(),
+      clientId: selectedClientId,
+      prodotto: product,
+      prezzo: Number(currentPrice),
+      stato: currentState,
+      timestamp: new Date().toISOString()
+    };
+    await addPurchase(purchase);
+    dom.productName.value = '';
+    const activeQuick = Array.from(dom.quickPrices).find(btn => btn.classList.contains('active'));
+    if (activeQuick) {
+      currentPrice = Number(activeQuick.dataset.price);
+    } else {
+      currentPrice = null;
+      dom.customPrice.value = '';
+    }
+    dom.productName.focus();
+    showToast('Riga aggiunta — Annulla?', 'success', undoLastInsert);
+    lastAddedPurchase = purchase;
+    dom.undoLast.disabled = false;
+    scheduleUndoTimeout();
+    await renderHistory();
+    updateStats();
+    updateAddButtonState();
+  }
+
+  // Scrive una riga acquisto nel DB
+  async function addPurchase(purchase) {
+    const tx = db.transaction(STORES.PURCHASES, 'readwrite');
+    tx.objectStore(STORES.PURCHASES).add(purchase);
+    await transactionComplete(tx);
+  }
+
+  async function editPurchase(id) {
+    const purchase = await getPurchase(id);
+    if (!purchase) return;
+    dom.purchaseModalProduct.value = purchase.prodotto;
+    dom.purchaseModalPrice.value = purchase.prezzo;
+    dom.purchaseModalState.value = purchase.stato;
+    editingPurchaseId = id;
+    openPurchaseModal();
+  }
+
+  async function togglePurchaseState(id) {
+    const purchase = await getPurchase(id);
+    if (!purchase) return;
+    purchase.stato = purchase.stato === 'acquistato' ? 'aggiunto' : 'acquistato';
+    await updatePurchase(purchase);
+    showToast(`Stato impostato su ${purchase.stato}`, 'success');
+    await renderHistory();
+    updateStats();
+  }
+
+  async function deletePurchase(id) {
+    const firstConfirm = confirm('Vuoi eliminare questa riga?');
+    if (!firstConfirm) return;
+    const secondConfirm = confirm('Confermi l\'eliminazione definitiva?');
+    if (!secondConfirm) return;
+    const tx = db.transaction(STORES.PURCHASES, 'readwrite');
+    tx.objectStore(STORES.PURCHASES).delete(id);
+    await transactionComplete(tx);
+    showToast('Riga eliminata', 'success');
+    await renderHistory();
+    updateStats();
+  }
+
+  async function getPurchase(id) {
+    const tx = db.transaction(STORES.PURCHASES, 'readonly');
+    const store = tx.objectStore(STORES.PURCHASES);
+    const request = store.get(id);
+    return await requestToPromise(request);
+  }
+
+  async function updatePurchase(purchase) {
+    const tx = db.transaction(STORES.PURCHASES, 'readwrite');
+    tx.objectStore(STORES.PURCHASES).put(purchase);
+    await transactionComplete(tx);
+  }
+
+  async function savePurchaseFromModal() {
+    if (!editingPurchaseId) return;
+    const purchase = await getPurchase(editingPurchaseId);
+    if (!purchase) return;
+    purchase.prodotto = dom.purchaseModalProduct.value.trim();
+    const priceValue = parsePrice(dom.purchaseModalPrice.value);
+    purchase.prezzo = priceValue;
+    purchase.stato = dom.purchaseModalState.value;
+    if (!purchase.prodotto || Number.isNaN(priceValue)) {
+      showToast('Compila tutti i campi', 'error');
+      return;
+    }
+    await updatePurchase(purchase);
+    closePurchaseModal();
+    showToast('Riga aggiornata', 'success');
+    await renderHistory();
+    updateStats();
+  }
+
+  function openPurchaseModal() {
+    dom.purchaseModal.hidden = false;
+    dom.purchaseModal.classList.add('visible');
+    dom.purchaseModalProduct.focus();
+  }
+
+  function closePurchaseModal() {
+    dom.purchaseModal.hidden = true;
+    dom.purchaseModal.classList.remove('visible');
+    editingPurchaseId = null;
+  }
+
+  async function handleSearch(event) {
+    const term = event.target.value.trim().toLowerCase();
+    const filtered = filterClients(term);
+    renderClientList(filtered);
+    renderSearchSuggestions(filtered, term);
+  }
+
+  function handleSearchKeys(event) {
+    if (['ArrowDown', 'ArrowUp', 'Enter'].includes(event.key)) {
+      event.preventDefault();
+    }
+    const activeResults = suggestionResults.length ? suggestionResults : searchResults;
+    if (event.key === 'ArrowDown') {
+      if (!activeResults.length) return;
+      keyboardIndex = (keyboardIndex + 1) % activeResults.length;
+      updateKeyboardFocus();
+    }
+    if (event.key === 'ArrowUp') {
+      if (!activeResults.length) return;
+      keyboardIndex = (keyboardIndex - 1 + activeResults.length) % activeResults.length;
+      updateKeyboardFocus();
+    }
+    if (event.key === 'Enter') {
+      if (!activeResults.length) return;
+      const targetIndex = keyboardIndex >= 0 ? keyboardIndex : 0;
+      const target = activeResults[targetIndex];
+      if (target) {
+        selectClient(target.id);
+        dom.clientSearch.select();
+        clearSearchSuggestions();
+      }
+    }
+  }
+
+  function updateKeyboardFocus() {
+    const suggestionItems = Array.from(dom.searchSuggestions.querySelectorAll('li'));
+    const targetItems = suggestionItems.length ? suggestionItems : Array.from(dom.clientList.querySelectorAll('li'));
+    dom.clientList.querySelectorAll('li').forEach(li => li.classList.remove('keyboard-focus'));
+    suggestionItems.forEach((li, index) => {
+      const active = index === keyboardIndex;
+      li.classList.toggle('keyboard-focus', active);
+      li.setAttribute('aria-selected', active ? 'true' : 'false');
+    });
+    if (!suggestionItems.length) {
+      targetItems.forEach((li, index) => li.classList.toggle('keyboard-focus', index === keyboardIndex));
+    }
+  }
+
+  function setActivePrice(price) {
+    currentPrice = price;
+    if (price !== null) {
+      dom.customPrice.value = '';
+    }
+    dom.quickPrices.forEach(btn => {
+      btn.classList.toggle('active', Number(btn.dataset.price) === price);
+    });
+    updateAddButtonState();
+  }
+
+  function clearActiveQuickPrice() {
+    dom.quickPrices.forEach(btn => btn.classList.remove('active'));
+  }
+
+  function updateAddButtonState() {
+    const productFilled = Boolean(dom.productName.value.trim());
+    const priceValid = currentPrice !== null && !Number.isNaN(currentPrice);
+    const hasClient = Boolean(selectedClientId);
+    const enabled = productFilled && priceValid && hasClient;
+    dom.addPurchase.disabled = !enabled;
+    let title = '';
+    if (!hasClient) title = 'Seleziona un cliente';
+    else if (!productFilled) title = 'Inserisci il nome prodotto';
+    else if (!priceValid) title = 'Scegli un prezzo';
+    dom.addPurchase.title = title;
+  }
+
+  function debounce(fn, delay) {
+    let timeout;
+    return function (...args) {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => fn.apply(this, args), delay);
+    };
+  }
+
+  function formatCurrency(value) {
+    return new Intl.NumberFormat('it-IT', { style: 'currency', currency: 'EUR' }).format(Number(value || 0));
+  }
+
+  function parsePrice(value) {
+    if (typeof value === 'number') return value;
+    if (typeof value !== 'string') return Number(value);
+    const normalized = value.replace(/\s/g, '').replace(',', '.');
+    return Number(normalized);
+  }
+
+  function formatTime(iso) {
+    const date = new Date(iso);
+    return date.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit' });
+  }
+
+  function capitalize(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
+
+  function normalizeSearch(nome, cognome) {
+    return `${nome} ${cognome}`.toLowerCase();
+  }
+
+  function updateStats() {
+    dom.statClients.textContent = clientsCache.length;
+    countPurchases().then(({ rows, total }) => {
+      dom.statPurchases.textContent = rows;
+      dom.statTotal.textContent = formatCurrency(total);
+    });
+  }
+
+  async function countPurchases() {
+    const tx = db.transaction(STORES.PURCHASES, 'readonly');
+    const store = tx.objectStore(STORES.PURCHASES);
+    const purchases = await requestToPromise(store.getAll());
+    const total = purchases.filter(p => p.stato === 'acquistato')
+      .reduce((sum, p) => sum + Number(p.prezzo), 0);
+    return { rows: purchases.length, total };
+  }
+
+  async function handleGlobalShortcuts(event) {
+    if (event.key === 'Escape') {
+      if (!dom.purchaseModal.hidden) {
+        event.preventDefault();
+        closePurchaseModal();
+        return;
+      }
+      if (!dom.modal.hidden) {
+        event.preventDefault();
+        closeModal();
+        return;
+      }
+      if (!dom.searchSuggestions.hidden) {
+        clearSearchSuggestions();
+        return;
+      }
+    }
+    if (event.ctrlKey && event.key.toLowerCase() === 'f') {
+      event.preventDefault();
+      dom.clientSearch.focus();
+      dom.clientSearch.select();
+    }
+    if (event.ctrlKey && event.key.toLowerCase() === 'n') {
+      event.preventDefault();
+      openClientModal();
+    }
+    if (document.body.contains(dom.modal) && !dom.modal.hidden) {
+      return; // evita scorciatoie quando il modal cliente è aperto
+    }
+    if (!dom.purchaseModal.hidden) {
+      return;
+    }
+    if (event.key === 'Enter' && document.activeElement === dom.productName && !dom.addPurchase.disabled) {
+      event.preventDefault();
+      dom.purchaseForm.requestSubmit();
+    }
+    if (PRICE_SHORTCUTS[event.code] !== undefined) {
+      const tag = event.target.tagName;
+      if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag) && event.target !== dom.productName) {
+        return;
+      }
+      event.preventDefault();
+      setActivePrice(PRICE_SHORTCUTS[event.code]);
+    }
+  }
+
+  async function openClientModal() {
+    dom.modal.hidden = false;
+    dom.modal.dataset.mode = 'new';
+    dom.modalNome.value = '';
+    dom.modalCognome.value = '';
+    dom.modalNote.value = '';
+    dom.modalNome.focus();
+  }
+
+  function closeModal() {
+    dom.modal.hidden = true;
+  }
+
+  async function saveClientFromModal() {
+    const nome = dom.modalNome.value.trim();
+    const cognome = dom.modalCognome.value.trim();
+    const note = dom.modalNote.value.trim();
+    if (!nome || !cognome) {
+      showToast('Nome e cognome sono obbligatori', 'error');
+      return;
+    }
+    const client = {
+      id: crypto.randomUUID(),
+      nome,
+      cognome,
+      note,
+      search: normalizeSearch(nome, cognome)
+    };
+    const tx = db.transaction(STORES.CLIENTS, 'readwrite');
+    tx.objectStore(STORES.CLIENTS).add(client);
+    await transactionComplete(tx);
+    closeModal();
+    clientsCache.push(client);
+    clientsCache.sort((a, b) => a.cognome.localeCompare(b.cognome, 'it', { sensitivity: 'base' }));
+    renderClientList(clientsCache);
+    clearSearchSuggestions();
+    showToast('Cliente creato', 'success');
+    updateStats();
+  }
+
+  function showToast(message, type = 'success', undoHandler) {
+    while (dom.toastContainer.children.length >= 3) {
+      dom.toastContainer.removeChild(dom.toastContainer.firstChild);
+    }
+    const toast = document.createElement('div');
+    toast.className = `toast ${type}`;
+    toast.textContent = message;
+    if (undoHandler) {
+      const btn = document.createElement('button');
+      btn.textContent = 'Annulla';
+      btn.addEventListener('click', () => {
+        undoHandler();
+        dom.toastContainer.removeChild(toast);
+      });
+      toast.appendChild(btn);
+    }
+    dom.toastContainer.appendChild(toast);
+    setTimeout(() => {
+      toast.classList.add('visible');
+    }, 10);
+    setTimeout(() => {
+      toast.remove();
+    }, 5000);
+  }
+
+  function scheduleUndoTimeout() {
+    clearTimeout(undoTimer);
+    undoTimer = setTimeout(() => {
+      lastAddedPurchase = null;
+      dom.undoLast.disabled = true;
+      undoTimer = null;
+    }, 5000);
+  }
+
+  async function undoLastInsert() {
+    if (!lastAddedPurchase) return;
+    clearTimeout(undoTimer);
+    undoTimer = null;
+    const tx = db.transaction(STORES.PURCHASES, 'readwrite');
+    tx.objectStore(STORES.PURCHASES).delete(lastAddedPurchase.id);
+    await transactionComplete(tx);
+    showToast('Ultimo inserimento annullato', 'success');
+    lastAddedPurchase = null;
+    dom.undoLast.disabled = true;
+    await renderHistory();
+    updateStats();
+  }
+
+  function toggleTheme() {
+    const app = document.querySelector('.app');
+    const next = app.dataset.theme === 'light' ? 'dark' : 'light';
+    app.dataset.theme = next;
+  }
+
+  async function exportPdf() {
+    const allData = await getDataGroupedByClient();
+    if (!allData.length) {
+      showToast('Nessun dato da esportare', 'error');
+      return;
+    }
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF({ unit: 'pt', format: 'a4' });
+    const title = `Ordini Live – ${new Date().toLocaleString('it-IT')}`;
+    doc.setFontSize(18);
+    doc.text(title, 40, 50);
+    let y = 80;
+    let overallTotal = 0;
+
+    for (const group of allData) {
+      const clientTitle = `${group.client.cognome} ${group.client.nome}`;
+      doc.setFontSize(16);
+      doc.text(clientTitle, 40, y);
+      y += 10;
+      const rows = group.purchases.map(p => [
+        p.prodotto,
+        formatCurrency(p.prezzo),
+        capitalize(p.stato),
+        formatTime(p.timestamp)
+      ]);
+      doc.autoTable({
+        startY: y + 10,
+        head: [['Prodotto', 'Prezzo', 'Stato', 'Ora']],
+        body: rows,
+        margin: { left: 40, right: 40 },
+        styles: { fontSize: 11 },
+        theme: 'striped',
+        didDrawPage: (data) => {
+          doc.setFontSize(10);
+          const pageStr = `Pagina ${doc.internal.getNumberOfPages()}`;
+          doc.text(pageStr, doc.internal.pageSize.getWidth() - 40, doc.internal.pageSize.getHeight() - 20, { align: 'right' });
+        }
+      });
+      y = doc.lastAutoTable.finalY + 10;
+      const totalClient = group.purchases
+        .filter(p => p.stato === 'acquistato')
+        .reduce((sum, p) => sum + Number(p.prezzo), 0);
+      overallTotal += totalClient;
+      doc.setFontSize(12);
+      doc.text(`Totale cliente: ${formatCurrency(totalClient)}`, 40, y + 10);
+      y += 40;
+      if (y > doc.internal.pageSize.getHeight() - 80) {
+        doc.addPage();
+        y = 60;
+      }
+    }
+
+    if (y > doc.internal.pageSize.getHeight() - 80) {
+      doc.addPage();
+      y = 60;
+    }
+    doc.setFontSize(14);
+    doc.text(`Totale generale: ${formatCurrency(overallTotal)}`, 40, y);
+    doc.save(`ordini-live-${Date.now()}.pdf`);
+  }
+
+  async function getDataGroupedByClient() {
+    const txClients = db.transaction(STORES.CLIENTS, 'readonly');
+    const clients = await requestToPromise(txClients.objectStore(STORES.CLIENTS).getAll());
+    const txPurchases = db.transaction(STORES.PURCHASES, 'readonly');
+    const purchases = await requestToPromise(txPurchases.objectStore(STORES.PURCHASES).getAll());
+    const map = new Map();
+    for (const client of clients) {
+      map.set(client.id, { client, purchases: [] });
+    }
+    for (const purchase of purchases) {
+      if (!map.has(purchase.clientId)) continue;
+      map.get(purchase.clientId).purchases.push(purchase);
+    }
+    const groups = Array.from(map.values()).filter(group => group.purchases.length > 0);
+    groups.forEach(group => {
+      group.purchases.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+    });
+    groups.sort((a, b) => {
+      const surname = a.client.cognome.localeCompare(b.client.cognome, 'it', { sensitivity: 'base' });
+      if (surname !== 0) return surname;
+      return a.client.nome.localeCompare(b.client.nome, 'it', { sensitivity: 'base' });
+    });
+    return groups;
+  }
+
+  async function exportJson() {
+    const clients = clientsCache;
+    const tx = db.transaction(STORES.PURCHASES, 'readonly');
+    const purchases = await requestToPromise(tx.objectStore(STORES.PURCHASES).getAll());
+    const payload = JSON.stringify({ clients, purchases }, null, 2);
+    const blob = new Blob([payload], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `mystery-product-backup-${Date.now()}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    showToast('Export JSON completato', 'success');
+  }
+
+  async function importJson(event) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    try {
+      const data = JSON.parse(text);
+      if (!Array.isArray(data.clients) || !Array.isArray(data.purchases)) {
+        throw new Error('Formato non valido');
+      }
+      const confirmImport = confirm('Importare il backup selezionato? Questa operazione sovrascrive i dati.');
+      if (!confirmImport) return;
+      const tx = db.transaction([STORES.CLIENTS, STORES.PURCHASES], 'readwrite');
+      const clientStore = tx.objectStore(STORES.CLIENTS);
+      const purchaseStore = tx.objectStore(STORES.PURCHASES);
+      clientStore.clear();
+      purchaseStore.clear();
+      for (const client of data.clients) {
+        client.search = normalizeSearch(client.nome, client.cognome);
+        clientStore.put(client);
+      }
+      for (const purchase of data.purchases) {
+        purchaseStore.put(purchase);
+      }
+      await transactionComplete(tx);
+      await loadClients();
+      renderClientList(clientsCache);
+      selectedClientId = null;
+      lastAddedPurchase = null;
+      dom.undoLast.disabled = true;
+      clearTimeout(undoTimer);
+      undoTimer = null;
+      updateClientSelectionUI();
+      await renderHistory();
+      updateStats();
+      updateAddButtonState();
+      showToast('Import completato', 'success');
+    } catch (error) {
+      showToast('Import fallito: ' + error.message, 'error');
+    } finally {
+      event.target.value = '';
+    }
+  }
+
+  async function resetDatabase() {
+    const first = confirm('Vuoi davvero azzerare il database?');
+    if (!first) return;
+    const second = confirm('Confermi la cancellazione di tutti i dati?');
+    if (!second) return;
+    const tx = db.transaction([STORES.CLIENTS, STORES.PURCHASES], 'readwrite');
+    tx.objectStore(STORES.CLIENTS).clear();
+    tx.objectStore(STORES.PURCHASES).clear();
+    await transactionComplete(tx);
+    clientsCache = [];
+    selectedClientId = null;
+    lastAddedPurchase = null;
+    dom.undoLast.disabled = true;
+    clearTimeout(undoTimer);
+    undoTimer = null;
+    renderClientList([]);
+    updateClientSelectionUI();
+    await renderHistory();
+    updateStats();
+    updateAddButtonState();
+    showToast('Database svuotato', 'success');
+  }
+
+  function requestToPromise(request) {
+    return new Promise((resolve, reject) => {
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  function transactionComplete(tx) {
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Registro Live Mystery Product</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=SF+Pro+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-/B8oH0+FK/vX1xT1kWzE8DqRL3OjaxAg/P6MqxsVXni4eWh05rq6ArtyTc95xJMu38xpv8uKXu95syEcxrPo1w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.29/jspdf.plugin.autotable.min.js" integrity="sha512-LlL7sRKqGZo4PMBVXgS5aXoaZySUdkGFUTkOcJCIZy9lEi5Vf3L7hIwrKyYVJZZzKzbwQ6vurSlBLL8GMDIS9A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script defer src="app.js"></script>
+</head>
+<body>
+  <div class="app" data-theme="light">
+    <header class="top-bar">
+      <div class="title-group">
+        <h1>Registro Live Mystery Product</h1>
+        <p class="subtitle">Monitoraggio acquisti in tempo reale</p>
+      </div>
+      <div class="top-actions">
+        <button id="themeToggle" class="ghost">🌗 Tema</button>
+        <button id="exportPdf" class="primary">Export PDF</button>
+        <button id="exportJson" class="ghost">Export JSON</button>
+        <label for="importJsonInput" class="ghost">Import JSON</label>
+        <input type="file" id="importJsonInput" accept="application/json" hidden>
+        <button id="resetDb" class="danger">Reset DB</button>
+      </div>
+    </header>
+
+    <section class="stats-bar" aria-live="polite">
+      <div class="stat"><span id="statClients">0</span><label>Clienti</label></div>
+      <div class="stat"><span id="statPurchases">0</span><label>Righe</label></div>
+      <div class="stat"><span id="statTotal">€0,00</span><label>Totale acquistato</label></div>
+    </section>
+
+    <main class="columns">
+      <section class="column clients" aria-label="Clienti">
+        <div class="search-wrap">
+          <div class="search-input-group">
+            <input id="clientSearch" type="search" placeholder="Cerca cliente… (Ctrl+F)" autocomplete="off" aria-autocomplete="list" aria-controls="searchSuggestions" aria-expanded="false" />
+            <ul id="searchSuggestions" class="search-suggestions" role="listbox" hidden></ul>
+          </div>
+          <button id="newClient" class="primary">+ Nuovo cliente</button>
+        </div>
+        <ul id="clientList" class="client-list" role="listbox"></ul>
+      </section>
+
+      <section class="column create" aria-label="Nuovo acquisto">
+        <header class="panel-header">
+          <h2 id="selectedClientName">Seleziona un cliente</h2>
+          <p id="selectedClientNotes" class="notes"></p>
+          <div class="total">Totale cliente: <strong id="clientTotal">€0,00</strong></div>
+        </header>
+        <form id="purchaseForm" autocomplete="off">
+          <label class="field">
+            <span>Nome prodotto</span>
+            <input type="text" id="productName" placeholder="Es. Crema alla vitamina E" required />
+          </label>
+          <div class="field">
+            <span>Prezzo rapido</span>
+            <div class="quick-prices" role="group" aria-label="Prezzi rapidi">
+              <button type="button" data-price="3" data-shortcut="1">3€ • ⌨1</button>
+              <button type="button" data-price="5" data-shortcut="2">5€ • ⌨2</button>
+              <button type="button" data-price="7" data-shortcut="3">7€ • ⌨3</button>
+              <button type="button" data-price="10" data-shortcut="4">10€ • ⌨4</button>
+              <button type="button" data-price="12" data-shortcut="5">12€ • ⌨5</button>
+              <button type="button" data-price="15" data-shortcut="6">15€ • ⌨6</button>
+              <button type="button" data-price="20" data-shortcut="7">20€ • ⌨7</button>
+              <button type="button" data-price="25" data-shortcut="8">25€ • ⌨8</button>
+              <button type="button" data-price="30" data-shortcut="9">30€ • ⌨9</button>
+              <button type="button" data-price="35" data-shortcut="0">35€ • ⌨0</button>
+              <button type="button" data-price="40" data-shortcut="=">40€ • ⌨=</button>
+            </div>
+          </div>
+          <label class="field">
+            <span>Altro €</span>
+            <input type="number" min="0" step="0.01" id="customPrice" placeholder="Inserisci importo" />
+          </label>
+          <div class="field state-toggle" role="radiogroup" aria-label="Stato acquisto">
+            <button type="button" data-state="acquistato" class="active" aria-pressed="true">Acquistato</button>
+            <button type="button" data-state="aggiunto" aria-pressed="false">Aggiunto</button>
+          </div>
+          <button type="submit" id="addPurchase" class="primary large" disabled>Aggiungi (Invio)</button>
+        </form>
+      </section>
+
+      <section class="column history" aria-label="Storico cliente">
+        <div class="history-header">
+          <div class="tabs" role="tablist">
+            <button type="button" class="active" data-filter="tutti" role="tab">Tutti</button>
+            <button type="button" data-filter="aggiunto" role="tab">Aggiunti</button>
+            <button type="button" data-filter="acquistato" role="tab">Acquistati</button>
+          </div>
+          <button id="undoLast" class="ghost" disabled>↩️ Annulla ultimo</button>
+        </div>
+        <table class="history-table">
+          <thead>
+            <tr><th>Ora</th><th>Prodotto</th><th>Prezzo</th><th>Stato</th><th>Azioni</th></tr>
+          </thead>
+          <tbody id="historyBody"></tbody>
+        </table>
+      </section>
+    </main>
+  </div>
+
+  <div id="modal" class="modal" role="dialog" aria-modal="true" hidden>
+    <div class="modal-content" role="document">
+      <header>
+        <h2 id="modalTitle">Nuovo cliente</h2>
+      </header>
+      <form id="modalForm">
+        <label class="field">
+          <span>Nome</span>
+          <input type="text" id="modalNome" required />
+        </label>
+        <label class="field">
+          <span>Cognome</span>
+          <input type="text" id="modalCognome" required />
+        </label>
+        <label class="field">
+          <span>Note</span>
+          <textarea id="modalNote" rows="3" placeholder="Informazioni utili"></textarea>
+        </label>
+        <div class="modal-actions">
+          <button type="button" class="ghost" id="modalCancel">Annulla</button>
+          <button type="submit" class="primary" id="modalSave">Salva</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div id="purchaseModal" class="modal" role="dialog" aria-modal="true" hidden>
+    <div class="modal-content" role="document">
+      <header>
+        <h2 id="purchaseModalTitle">Modifica acquisto</h2>
+      </header>
+      <form id="purchaseModalForm">
+        <label class="field">
+          <span>Nome prodotto</span>
+          <input type="text" id="purchaseModalProduct" required />
+        </label>
+        <label class="field">
+          <span>Prezzo (€)</span>
+          <input type="number" id="purchaseModalPrice" min="0" step="0.01" required />
+        </label>
+        <label class="field">
+          <span>Stato</span>
+          <select id="purchaseModalState">
+            <option value="acquistato">Acquistato</option>
+            <option value="aggiunto">Aggiunto</option>
+          </select>
+        </label>
+        <div class="modal-actions">
+          <button type="button" class="ghost" id="purchaseModalCancel">Annulla</button>
+          <button type="submit" class="primary" id="purchaseModalSave">Salva</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div id="toastContainer" class="toast-container" aria-live="polite"></div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=SF+Pro+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-/B8oH0+FK/vX1xT1kWzE8DqRL3OjaxAg/P6MqxsVXni4eWh05rq6ArtyTc95xJMu38xpv8uKXu95syEcxrPo1w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.29/jspdf.plugin.autotable.min.js" integrity="sha512-LlL7sRKqGZo4PMBVXgS5aXoaZySUdkGFUTkOcJCIZy9lEi5Vf3L7hIwrKyYVJZZzKzbwQ6vurSlBLL8GMDIS9A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script defer src="app.js"></script>
 </head>
 <body>
@@ -21,7 +19,7 @@
       </div>
       <div class="top-actions">
         <button id="themeToggle" class="ghost">🌗 Tema</button>
-        <button id="exportPdf" class="primary">Export PDF</button>
+        <button id="exportText" class="primary">Export testo</button>
         <button id="exportJson" class="ghost">Export JSON</button>
         <label for="importJsonInput" class="ghost">Import JSON</label>
         <input type="file" id="importJsonInput" accept="application/json" hidden>

--- a/styles.css
+++ b/styles.css
@@ -432,6 +432,10 @@ input:focus, textarea:focus, select:focus {
   color: var(--warning);
 }
 
+.modal[hidden] {
+  display: none !important;
+}
+
 .modal {
   position: fixed;
   inset: 0;

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,518 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #f5f5f7;
+  --bg-elevated: #ffffffcc;
+  --bg-card: #ffffff;
+  --text: #1d1d1f;
+  --text-soft: #6e6e73;
+  --primary: #007aff;
+  --primary-dark: #0051a8;
+  --warning: #ff9f0a;
+  --danger: #ff3b30;
+  --border: #d2d2d7;
+  --radius: 18px;
+  --shadow: 0 30px 60px -30px rgba(31, 31, 31, 0.5);
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+[data-theme="dark"] {
+  --bg: #000000;
+  --bg-elevated: rgba(30, 30, 30, 0.85);
+  --bg-card: #1c1c1e;
+  --text: #f5f5f7;
+  --text-soft: #98989d;
+  --border: #3a3a3c;
+  --warning: #ffb340;
+  --shadow: 0 30px 60px -35px rgba(0, 0, 0, 0.8);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.8) 0%, transparent 60%), var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 32px 48px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--bg-elevated);
+  backdrop-filter: blur(16px);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.title-group h1 {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  font-size: 16px;
+  color: var(--text-soft);
+}
+
+.top-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+button {
+  font: inherit;
+  border: none;
+  border-radius: 14px;
+  padding: 12px 20px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  background: var(--bg-card);
+  color: var(--text);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), inset 0 -1px 0 rgba(0,0,0,0.05);
+}
+
+button:hover {
+  transform: translateY(-2px);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+button.primary {
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 0 12px 24px -12px var(--primary);
+}
+
+button.primary:hover {
+  background: var(--primary-dark);
+}
+
+button.ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+}
+
+button.danger {
+  background: var(--danger);
+  color: #fff;
+}
+
+button.large {
+  width: 100%;
+  padding: 16px;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.stats-bar {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.stat {
+  background: var(--bg-elevated);
+  backdrop-filter: blur(12px);
+  border-radius: var(--radius);
+  padding: 18px 24px;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.stat span {
+  display: block;
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.stat label {
+  display: block;
+  margin-top: 4px;
+  font-size: 14px;
+  color: var(--text-soft);
+}
+
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr 1fr;
+  gap: 24px;
+  align-items: stretch;
+}
+
+.column {
+  background: var(--bg-elevated);
+  backdrop-filter: blur(20px);
+  border-radius: var(--radius);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: var(--shadow);
+}
+
+.search-wrap {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.search-input-group {
+  position: relative;
+  flex: 1;
+}
+
+.search-input-group input {
+  width: 100%;
+}
+
+.search-suggestions {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 6px 0;
+  list-style: none;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 16px 32px -24px rgba(0, 0, 0, 0.6);
+  z-index: 25;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.search-suggestions[hidden] {
+  display: none;
+}
+
+.search-suggestions li {
+  padding: 10px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  cursor: pointer;
+  color: var(--text);
+}
+
+.search-suggestions li strong {
+  font-weight: 600;
+}
+
+.search-suggestions li small {
+  color: var(--text-soft);
+  font-size: 12px;
+}
+
+.search-suggestions mark {
+  background: rgba(0, 122, 255, 0.18);
+  color: inherit;
+  border-radius: 4px;
+  padding: 0 2px;
+}
+
+.search-suggestions li:hover,
+.search-suggestions li.keyboard-focus {
+  background: rgba(0, 122, 255, 0.12);
+}
+
+input, textarea, select {
+  font: inherit;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: var(--bg-card);
+  padding: 12px 16px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+  color: var(--text);
+}
+
+input:focus, textarea:focus, select:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.client-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 560px;
+  overflow-y: auto;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+.client-list li {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  background: var(--bg-card);
+  transition: background 0.2s ease;
+}
+
+.client-list li:last-child {
+  border-bottom: none;
+}
+
+.client-list li:hover, .client-list li:focus {
+  background: rgba(0, 122, 255, 0.12);
+}
+
+.client-list li.keyboard-focus {
+  outline: 2px solid var(--primary);
+  outline-offset: -4px;
+}
+
+.client-list li.selected {
+  background: rgba(0, 122, 255, 0.22);
+  border-left: 4px solid var(--primary);
+  padding-left: 14px;
+}
+
+.client-list .name {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.client-list .note {
+  font-size: 13px;
+  color: var(--text-soft);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 600;
+}
+
+.panel-header .notes {
+  margin: 6px 0 0;
+  color: var(--text-soft);
+  font-size: 14px;
+}
+
+.panel-header .total {
+  margin-top: 12px;
+  font-size: 18px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.quick-prices {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.quick-prices button {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.quick-prices button.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.state-toggle {
+  display: inline-flex;
+  gap: 12px;
+}
+
+.state-toggle button {
+  flex: 1;
+}
+
+.state-toggle button.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.tabs {
+  display: inline-flex;
+  background: var(--bg-card);
+  border-radius: 999px;
+  padding: 4px;
+  border: 1px solid var(--border);
+}
+
+.tabs button {
+  border-radius: 999px;
+  padding: 10px 18px;
+  background: transparent;
+}
+
+.tabs button.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 15px;
+}
+
+.history-table th,
+.history-table td {
+  text-align: left;
+  padding: 12px 10px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+
+.history-table tbody tr:hover {
+  background: rgba(0, 122, 255, 0.08);
+}
+
+.history-table td.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.history-table button {
+  padding: 6px 10px;
+  font-size: 14px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.badge.acquistato {
+  background: rgba(0, 122, 255, 0.12);
+  color: var(--primary-dark);
+}
+
+.badge.aggiunto {
+  background: rgba(255, 159, 10, 0.16);
+  color: var(--warning);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.modal-content {
+  background: var(--bg-card);
+  padding: 28px;
+  border-radius: var(--radius);
+  width: min(420px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  box-shadow: var(--shadow);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.toast-container {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 30;
+}
+
+.toast {
+  background: var(--bg-card);
+  border-radius: 16px;
+  padding: 14px 20px;
+  box-shadow: 0 20px 40px -24px rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.toast.success {
+  border-left: 4px solid var(--primary);
+}
+
+.toast.error {
+  border-left: 4px solid var(--danger);
+}
+
+.toast button {
+  font-size: 14px;
+  padding: 8px 14px;
+}
+
+@media print {
+  body {
+    background: #fff;
+  }
+  .top-bar, .stats-bar, .columns > .create, .columns > .clients, .top-actions, #toastContainer, #modal {
+    display: none !important;
+  }
+  .columns {
+    grid-template-columns: 1fr;
+  }
+  .history {
+    box-shadow: none;
+    background: #fff;
+  }
+}
+
+@media (max-width: 1200px) {
+  .columns {
+    grid-template-columns: 1fr;
+  }
+  .client-list {
+    max-height: 240px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dropdown of instant client suggestions with keyboard support to speed up customer selection
- refine the edit purchase modal wiring, including escape/overlay closing and robust price parsing
- style the search area for the new suggestion list to match the Apple-inspired aesthetic

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e0f520cc8323aa8723d61b5e47a9